### PR TITLE
적합도 정규화시켜도 룰렛 휠 선택법 적용 가능하도록 수정

### DIFF
--- a/TSP_GA_Solving.py
+++ b/TSP_GA_Solving.py
@@ -94,7 +94,7 @@ def best_chroms_selection(population, num = 2):
     return inds
 
 def roulette_wheel_selection(population, num = 2):
-    _, fitness_of_chroms = cal_fitness_of_population(population, normalize_fitness)
+    _, fitness_of_chroms = cal_fitness_of_population(population, normalize=False)
     sum_of_scores = sum(fitness_of_chroms)
     num_rand = random.sample(range(0, sum_of_scores), num)
     accumulated_score = [0] * len(population)


### PR DESCRIPTION
1. roulette_wheel_selection()함수 내 적합도 계산시 정규화하지 않도록 cal_fitness_of_population()함수에 normalize 인자 False 전달.